### PR TITLE
Implement service

### DIFF
--- a/GuideListReactive.xcodeproj/project.pbxproj
+++ b/GuideListReactive.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		7475F66322723B5500CDADFA /* XCTestCase+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7475F66222723B5500CDADFA /* XCTestCase+Extensions.swift */; };
 		7475F66622723B6A00CDADFA /* Guide.json in Resources */ = {isa = PBXBuildFile; fileRef = 7475F66522723B6A00CDADFA /* Guide.json */; };
 		7475F66922723B9500CDADFA /* GuideTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7475F66822723B9500CDADFA /* GuideTests.swift */; };
+		7475F66B22723BFD00CDADFA /* Service.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7475F66A22723BFD00CDADFA /* Service.swift */; };
 		74905E88227184FC0062204C /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74905E87227184FC0062204C /* AppDelegate.swift */; };
 		74905E8F227185000062204C /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 74905E8E227185000062204C /* Assets.xcassets */; };
 		74905E92227185000062204C /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74905E90227185000062204C /* LaunchScreen.storyboard */; };
@@ -58,6 +59,7 @@
 		7475F66222723B5500CDADFA /* XCTestCase+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Extensions.swift"; sourceTree = "<group>"; };
 		7475F66522723B6A00CDADFA /* Guide.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = Guide.json; sourceTree = "<group>"; };
 		7475F66822723B9500CDADFA /* GuideTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GuideTests.swift; sourceTree = "<group>"; };
+		7475F66A22723BFD00CDADFA /* Service.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Service.swift; sourceTree = "<group>"; };
 		74905E84227184FC0062204C /* GuideList.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = GuideList.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		74905E87227184FC0062204C /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		74905E8E227185000062204C /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -108,6 +110,7 @@
 		745EA11B227186580083FDF2 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				7475F66A22723BFD00CDADFA /* Service.swift */,
 				7475F66022723B3700CDADFA /* Guide.swift */,
 			);
 			path = Model;
@@ -328,6 +331,7 @@
 				7475F66122723B3700CDADFA /* Guide.swift in Sources */,
 				74905E88227184FC0062204C /* AppDelegate.swift in Sources */,
 				7475F65F22723ABE00CDADFA /* NetworkClient.swift in Sources */,
+				7475F66B22723BFD00CDADFA /* Service.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Model/Service.swift
+++ b/Source/Model/Service.swift
@@ -1,0 +1,84 @@
+import RxSwift
+import RxCocoa
+
+class Service {
+	
+	private let imageCache = NSCache<NSString, NSData>()
+	
+	private let networkClient: NetworkClient
+	
+	init(networkClient: NetworkClient) {
+		self.networkClient = networkClient
+	}
+	
+	func requestGuides() -> Observable<[Guide]> {
+		// Internal struct matching the object returned by the endpoint
+		struct Response: Decodable {
+			let data: [Guide]
+		}
+
+		return Observable.create { [weak self] observer -> Disposable in
+			self?.networkClient.request(Endpoint<Response>(path: "upcomingGuides", httpMethod: .get)) {
+				switch $0 {
+				case .success(let response):
+					observer.onNext(response.data)
+					observer.onCompleted()
+				case .failure(let error):
+					observer.onError(error)
+					observer.onCompleted()
+				}
+			}
+			return Disposables.create()
+		}.retry(2)
+	}
+	
+	/// Request an image resource, if present in cache no request is send.
+	func requestImageData(for url: URL) -> Observable<Data?> {
+		return Observable.create { [weak self] observer -> Disposable in
+			let cacheKey = NSString(string: url.absoluteString)
+			if let data = self?.imageCache.object(forKey: cacheKey) as Data? {
+				observer.onNext(data)
+				observer.onCompleted()
+			} else {
+				URLSession.shared.dataTask(with: url) { (data, response, error) in
+					if let error = error {
+						observer.onError(error)
+						return
+					}
+					if let statusCode = (response as? HTTPURLResponse)?.statusCode, statusCode >= 400 {
+						observer.onError(Error.imageDataNotFound)
+						return
+					}
+					guard let data = data else {
+						observer.onError(Error.imageDataNotFound)
+						return
+					}
+					// store in cache
+					self?.imageCache.setObject(data as NSData, forKey: cacheKey)
+					observer.onNext(data)
+					observer.onCompleted()
+					return
+					}.resume()
+			}
+			return Disposables.create()
+		}.retry(2)
+	}
+	
+	func clearImageCache() {
+		self.imageCache.removeAllObjects()
+	}
+}
+
+// MARK: Error
+
+extension Service {
+	enum Error: Swift.Error {
+		case imageDataNotFound
+		
+		var localizedDescription: String {
+			switch self {
+			case .imageDataNotFound: return NSLocalizedString("No image data", comment: "Service error message")
+			}
+		}
+	}
+}


### PR DESCRIPTION
Service layer for fetching a list of guides or image data. Imagedata is cached using `NSCache`. `requestGuides()` uses the custom `NetworkClient` and `requestImageData(for:)` uses `URLSession`.
Could later be extend to wrap a database as well.